### PR TITLE
cb close chan rather than put nil

### DIFF
--- a/src/com/dept24c/vivo.cljc
+++ b/src/com/dept24c/vivo.cljc
@@ -6,6 +6,11 @@
    [com.dept24c.vivo.utils :as u]
    [deercreeklabs.async-utils :as au]))
 
+(defn put? [port x]
+  (if (nil? x)
+    (ca/close! port)
+    (ca/put! port x)))
+
 ;;;;;;;;;;;;;;;;;;;; Server fns ;;;;;;;;;;;;;;;;;;;;
 
 #?(:clj
@@ -52,7 +57,7 @@
 (defn <update-state!
   ([vc update-commands]
    (let [ch (ca/chan)
-         cb #(ca/put! ch %)]
+         cb #(put? ch %)]
      (u/update-state! vc update-commands cb)
      ch)))
 
@@ -67,7 +72,7 @@
 (defn <set-state!
   ([vc path arg]
    (let [ch (ca/chan)
-         cb #(ca/put! ch %)]
+         cb #(put? ch %)]
      (set-state! vc path arg cb)
      ch)))
 
@@ -83,7 +88,7 @@
 (defn <log-in!
   [vc identifier secret]
   (let [ch (ca/chan)
-        cb #(ca/put! ch %)]
+        cb #(put? ch %)]
     (u/log-in! vc identifier secret cb)
     ch))
 

--- a/test/com/dept24c/integration/integration_test.cljc
+++ b/test/com/dept24c/integration/integration_test.cljc
@@ -248,6 +248,9 @@
                sub-map '{subject-id :vivo/subject-id}
                unsub! (vivo/subscribe! vc sub-map nil #(ca/put! state-ch %)
                                        "test")
+               login-fail (au/<? (vivo/<log-in!
+                                  vc (str/upper-case tu/test-identifier)
+                                  tu/test-incorrect-secret))
                _ (is (= {'subject-id nil} (au/<? state-ch)))
                login-ret (au/<? (vivo/<log-in!
                                  vc (str/upper-case tu/test-identifier)


### PR DESCRIPTION
In the log-in case you end up calling `<log-in!` in the vivo client which is a go block so it returns a channel. When the login fails the go block returns nil. You can't put nil on a channel but go blocks handle this gracefully by closing the response channel rather than putting nil. This extends those semantics down the chain into the call back of the caller which is also a channel returning function. There were a few other cases as well although I didn't look into them really deeply. If this solution is satisfactory we could choose to move `put?` into async-utils. I acknowledge that I'm really quite unaware of all that's really going on here and welcome any feedback. I hope this at least starts the conversation even if there's a better way to solve the issue. I did also use this local version of vivo in the oncurrent app and it fixes the bad credentials bug.