### PR TITLE
fix inconsistent log-in async semantics

### DIFF
--- a/src/com/dept24c/vivo.cljc
+++ b/src/com/dept24c/vivo.cljc
@@ -76,16 +76,15 @@
 
 (defn log-in!
   ([vc identifier secret]
-   (u/log-in! vc identifier secret nil))
+   (log-in! vc identifier secret identity))
   ([vc identifier secret cb]
-   (u/log-in! vc identifier secret cb)))
+   (au/<?? (u/<log-in! vc identifier secret cb))))
 
 (defn <log-in!
-  [vc identifier secret]
-  (let [ch (ca/chan)
-        cb #(ca/put! ch %)]
-    (u/log-in! vc identifier secret cb)
-    ch))
+  ([vc identifier secret]
+   (<log-in! vc identifier secret identity))
+  ([vc identifier secret cb]
+   (u/<log-in! vc identifier secret cb)))
 
 (defn <log-in-w-token!
   [vc token]

--- a/src/com/dept24c/vivo/client.cljc
+++ b/src/com/dept24c/vivo/client.cljc
@@ -200,7 +200,7 @@
               writer-sch (au/<? (u/<fp->schema this (:fp ret)))]
           (l/deserialize value-sch writer-sch (:bytes ret))))))
 
-  (log-in! [this identifier secret cb]
+  (<log-in! [this identifier secret cb]
     (when-not capsule-client
       (throw
        (ex-info (str "Can't log in because the :get-server-url "
@@ -217,12 +217,10 @@
               {:keys [subject-id]} ret]
           (when subject-id
             (set-subject-id! subject-id))
-          (when cb
-            (cb ret)))
+          (cb ret))
         (catch #?(:cljs js/Error :clj Throwable) e
           (log-error (str "Exception in log-in!" (u/ex-msg-and-stacktrace e)))
-          (when cb
-            (cb e))))))
+          (cb e)))))
 
   (<log-in-w-token! [this token]
     (when-not capsule-client

--- a/src/com/dept24c/vivo/utils.cljc
+++ b/src/com/dept24c/vivo/utils.cljc
@@ -60,7 +60,7 @@
   (get-local-state [this sub-map resolution-map component-name])
   (handle-sys-state-changed [this arg metadata])
   (handle-updates [this updates cb])
-  (log-in! [this identifier secret cb])
+  (<log-in! [this identifier secret cb])
   (logged-in? [this])
   (<log-in-w-token! [this token])
   (<log-out! [this])

--- a/test/com/dept24c/integration/integration_test.cljc
+++ b/test/com/dept24c/integration/integration_test.cljc
@@ -249,9 +249,9 @@
                unsub! (vivo/subscribe! vc sub-map nil #(ca/put! state-ch %)
                                        "test")
                _ (is (= {'subject-id nil} (au/<? state-ch)))
-               login-ret (au/<? (vivo/<log-in!
-                                 vc (str/upper-case tu/test-identifier)
-                                 tu/test-secret))]
+               login-ret (vivo/log-in!
+                           vc (str/upper-case tu/test-identifier)
+                           tu/test-secret)]
            (when-not login-ret
              (throw (ex-info "Login failed. This is unexpected."
                              (u/sym-map login-ret))))


### PR DESCRIPTION
Fixes the async semantics of `log-in`

Consider
```clojure
(vivo/<log-in!
  vc (str/upper-case tu/test-identifier)
  tu/test-secret)
```
I can take from the returned channel via au/<?? and get the subject-id and token.

Now consider
```clojure
(vivo/log-in!
  vc (str/upper-case tu/test-identifier)
  tu/test-incorrect-secret)
```
Since I don't pass in a `cb` it passes in `nil` as the `cb`. However `log-in!` that gets called in client.cljc uses a `go` block and so actually returns a channel but since the name of the public fn `log-in!` doesn't start with `<` I didn't expect this. Also since `cb` is `nil` the `go` block returns `nil` and therefore closes the channel that it shouldn't have returned in the first place and thus the call to the public `log-in!` returns `nil` in both cases of login success and failure.