### PR TITLE
dev-repl work from empty ~/.m2/repository

### DIFF
--- a/bin/dev-repl
+++ b/bin/dev-repl
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-clj -M:clj:cider-clj:cider-nrepl:dev
+clj -M:clj:cider-clj:dev

--- a/deps.edn
+++ b/deps.edn
@@ -17,15 +17,15 @@
              "clojars" {:url "https://repo.clojars.org/"}}
 
  :aliases
- {:cider-clj {:main-opts ["-m" "nrepl.cmdline" "--middleware"
+ {:cider-clj {:extra-deps {cider/cider-nrepl {:mvn/version "0.26.0"}}
+              :main-opts ["-m" "nrepl.cmdline" "--middleware"
                           "[cider.nrepl/cider-middleware]"]}
 
-  :cider-cljs {:extra-deps {cider/piggieback {:mvn/version "0.5.2"}}
+  :cider-cljs {:extra-deps {cider/cider-nrepl {:mvn/version "0.26.0"}
+                            cider/piggieback {:mvn/version "0.5.2"}}
                :main-opts
                ["-m" "nrepl.cmdline" "--middleware"
                 "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"]}
-
-  :cider-nrepl {:extra-deps {cider/cider-nrepl {:mvn/version "0.26.0"}}}
 
   :clj {:extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
 


### PR DESCRIPTION
If you have an empty ~/.m2/repository (as I did when trying to debug something else) I found that `clj` `Could not locate nrepl/cmdline__init.class, nrepl/cmdline.clj or nrepl/cmdline.cljc on classpath.` Apparently it tries to locate the main entrypoint before downloading dependencies. I realize now the version number is specified in two places but my opinion is that this is preferable to the confusion that may ensue for newcomers though I'm happy to hear another opinion.