### PR TITLE
Update resolution-map for use-vivo-state

### DIFF
--- a/src/com/dept24c/vivo/react.cljc
+++ b/src/com/dept24c/vivo/react.cljc
@@ -114,20 +114,25 @@
    (use-vivo-state vc sub-map component-name resolution-map []))
   ([vc sub-map component-name resolution-map parents]
    #?(:cljs
-      (let [[state set-state!] (use-state nil)
-            subscribe*! (fn []
-                          (let [opts {:parents parents
-                                      :react? true
-                                      :resolution-map resolution-map}
-                                update-fn (fn [new-state]
-                                            (set-state! new-state))]
-                            (-> (u/subscribe-to-state! vc component-name
-                                                       sub-map update-fn opts)
-                                (set-state!))
-                            #(u/unsubscribe-from-state! vc component-name)))]
-        ; todo: update the dependencies vector which trigger re-subscribe!
-        (use-effect subscribe*! #js [])
-        state))))
+      (let [[_ render!] (use-state nil)
+            subscribe*! #(let [opts {:parents parents
+                                     :react? true
+                                     :resolution-map resolution-map}
+                               update-fn (fn [new-state]
+                                           (render! (u/current-time-ms)))]
+                           (u/subscribe-to-state! vc component-name sub-map
+                                                  update-fn opts))
+            cleanup-effect (fn []
+                             #(u/unsubscribe-from-state! vc component-name))
+            sub-info (u/get-subscription-info vc component-name)]
+        (use-effect cleanup-effect #js [])
+        (if (not sub-info)
+          (subscribe*!)
+          (if (= resolution-map (:resolution-map sub-info))
+            (:state sub-info)
+            (do
+              (u/unsubscribe-from-state! vc component-name)
+              (subscribe*!))))))))
 
 (defn use-topic-subscription
   "React hook for Vivo topic subscriptions."


### PR DESCRIPTION
The subscription need to be updated when the resolution-map's value is changed.
The previous implementation is restored.