### PR TITLE
Add empty token array on subject creation

### DIFF
--- a/src/com/dept24c/vivo/server.clj
+++ b/src/com/dept24c/vivo/server.clj
@@ -119,7 +119,8 @@
    temp-storage perm-storage]
   (au/go
     (let [{:keys [identifier-to-subject-id-data-id
-                  subject-id-to-hashed-secret-data-id]} dbi
+                  subject-id-to-hashed-secret-data-id
+                  subject-id-to-tokens-data-id]} dbi
           new-dbi (assoc dbi
                          :subject-id-to-hashed-secret-data-id
                          (:new-data-id
@@ -138,7 +139,16 @@
                                   [{:path [identifier]
                                     :op :set
                                     :arg requested-subject-id}]
-                                  nil branch temp-storage perm-storage))))]
+                                  nil branch temp-storage perm-storage)))
+                         :subject-id-to-tokens-data-id
+                         (:new-data-id
+                          (au/<?? (<update-storage
+                                   subject-id-to-tokens-data-id
+                                   u/subject-id-to-tokens-schema
+                                   [{:path [requested-subject-id]
+                                     :op :set
+                                     :arg []}]
+                                   nil branch temp-storage perm-storage))))]
       {:dbi new-dbi
        :update-infos []})))
 


### PR DESCRIPTION
This fixes a bug where password reset was failing between app start up
and first user log in.

The db-info contains a key :subject-id-to-tokens-data-id that we
expect is mandatory but was not set until the first user login. This
resulted in errors if something (such as storing a new password after
password reset) was to happen after app startup but before anyone had
logged in.