### PR TITLE
Don't assume existence of tokens when changing secret

### DIFF
--- a/src/com/dept24c/vivo/server.clj
+++ b/src/com/dept24c/vivo/server.clj
@@ -211,19 +211,19 @@
           ;; Use loop here to stay in go block
           new-dbi (loop [new-dbi dbi*
                          [token & more] tokens]
-                    (let [new-dbi* (assoc new-dbi
-                                          :token-to-token-info-data-id
-                                          (:new-data-id
-                                           (au/<? (<update-storage
-                                                   token-to-token-info-data-id
-                                                   u/token-map-schema
-                                                   [{:path [token]
-                                                     :op :remove}]
-                                                   nil branch temp-storage
-                                                   perm-storage))))]
-                      (if (seq more)
-                        (recur new-dbi* more)
-                        new-dbi*)))]
+                    (if token
+                      (let [new-dbi* (assoc new-dbi
+                                            :token-to-token-info-data-id
+                                            (:new-data-id
+                                             (au/<? (<update-storage
+                                                     token-to-token-info-data-id
+                                                     u/token-map-schema
+                                                     [{:path [token]
+                                                       :op :remove}]
+                                                     nil branch temp-storage
+                                                     perm-storage))))]
+                        (recur new-dbi* more))
+                      new-dbi))]
       {:dbi new-dbi
        :update-infos []})))
 


### PR DESCRIPTION
Non-signed in users changing their password can have no associated
tokens so we shouldn't assume that they do.

This commit changes the loop from assuming 1+ tokens to assuming 0+
tokens.